### PR TITLE
Demonstrate the correct way to send a welcome message in 1:1

### DIFF
--- a/template-bot-master-csharp/Properties/Strings.Designer.cs
+++ b/template-bot-master-csharp/Properties/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Teams.TemplateBotCSharp.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -84,6 +84,15 @@ namespace Microsoft.Teams.TemplateBotCSharp.Properties {
         internal static string AuthSampleCardTitle {
             get {
                 return ResourceManager.GetString("AuthSampleCardTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Hello, I&apos;m your new bot!.
+        /// </summary>
+        internal static string BotWelcomeMessage {
+            get {
+                return ResourceManager.GetString("BotWelcomeMessage", resourceCulture);
             }
         }
         

--- a/template-bot-master-csharp/Properties/Strings.resx
+++ b/template-bot-master-csharp/Properties/Strings.resx
@@ -801,4 +801,7 @@
   <data name="RemoveLike" xml:space="preserve">
     <value>Like Removed!!</value>
   </data>
+  <data name="BotWelcomeMessage" xml:space="preserve">
+    <value>Hello, I'm your new bot!</value>
+  </data>
 </root>

--- a/template-bot-master-csharp/src/controllers/MessagesController.cs
+++ b/template-bot-master-csharp/src/controllers/MessagesController.cs
@@ -246,7 +246,6 @@ namespace Microsoft.Teams.TemplateBotCSharp
                 ChannelId = message.ChannelId,
                 Timestamp = message.Timestamp,
                 LocalTimestamp = message.LocalTimestamp,
-                Locale = message.Locale,
                 Entities = message.Entities,
                 MembersAdded = new List<ChannelAccount> { message.Recipient },
             };

--- a/template-bot-master-csharp/src/controllers/MessagesController.cs
+++ b/template-bot-master-csharp/src/controllers/MessagesController.cs
@@ -245,8 +245,6 @@ namespace Microsoft.Teams.TemplateBotCSharp
                 ChannelData = message.ChannelData,
                 ChannelId = message.ChannelId,
                 Timestamp = message.Timestamp,
-                LocalTimestamp = message.LocalTimestamp,
-                Entities = message.Entities,
                 MembersAdded = new List<ChannelAccount> { message.From, message.Recipient },
             };
             return await this.Post(conversationUpdateMessage, cancellationToken);

--- a/template-bot-master-csharp/src/controllers/MessagesController.cs
+++ b/template-bot-master-csharp/src/controllers/MessagesController.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Teams.TemplateBotCSharp
 
                     // Create the welcome message to send
                     Activity welcomeMessage = message.CreateReply();
-                    welcomeMessage.Text = "Hello, I'm your new bot!";
+                    welcomeMessage.Text = Strings.BotWelcomeMessage;
 
                     if (!(message.Conversation.IsGroup ?? false))
                     {
@@ -165,6 +165,7 @@ namespace Microsoft.Teams.TemplateBotCSharp
                             var address = Address.FromActivity(message);
                             var botDataStore = scope.Resolve<IBotDataStore<BotData>>();
                             var botData = await botDataStore.LoadAsync(address, BotStoreType.BotUserData, cancellationToken);
+
                             if (!botData.GetProperty<bool>("IsFreSent"))
                             {
                                 await connectorClient.Conversations.ReplyToActivityWithRetriesAsync(welcomeMessage, cancellationToken);
@@ -184,7 +185,7 @@ namespace Microsoft.Teams.TemplateBotCSharp
                     }
                     else
                     {
-                        // Team event (bot or user was added to a team)
+                        // Not 1:1 chat event (bot or user was added to a team or group chat)
                         if (botWasAdded)
                         {
                             // Bot was added to the team
@@ -232,7 +233,7 @@ namespace Microsoft.Teams.TemplateBotCSharp
 
             // If you need to reset the user state in other services your app uses, do it here.
 
-            // Synthesize a conversation update event
+            // Synthesize a conversation update event and simulate the bot receiving it
             // Note that this is a fake event, as Teams does not support deleting a 1:1 conversation and re-creating it
             var conversationUpdateMessage = new Activity {
                 Type = ActivityTypes.ConversationUpdate,
@@ -243,6 +244,10 @@ namespace Microsoft.Teams.TemplateBotCSharp
                 Conversation = message.Conversation,
                 ChannelData = message.ChannelData,
                 ChannelId = message.ChannelId,
+                Timestamp = message.Timestamp,
+                LocalTimestamp = message.LocalTimestamp,
+                Locale = message.Locale,
+                Entities = message.Entities,
                 MembersAdded = new List<ChannelAccount> { message.Recipient },
             };
             return await this.Post(conversationUpdateMessage, cancellationToken);

--- a/template-bot-master-csharp/src/controllers/MessagesController.cs
+++ b/template-bot-master-csharp/src/controllers/MessagesController.cs
@@ -247,7 +247,7 @@ namespace Microsoft.Teams.TemplateBotCSharp
                 Timestamp = message.Timestamp,
                 LocalTimestamp = message.LocalTimestamp,
                 Entities = message.Entities,
-                MembersAdded = new List<ChannelAccount> { message.Recipient },
+                MembersAdded = new List<ChannelAccount> { message.From, message.Recipient },
             };
             return await this.Post(conversationUpdateMessage, cancellationToken);
         }

--- a/template-bot-master-csharp/src/controllers/MessagesController.cs
+++ b/template-bot-master-csharp/src/controllers/MessagesController.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Teams.TemplateBotCSharp
                 {
                     // Determine if the bot was added to the team/conversation
                     var botId = message.Recipient.Id;
-                    var botWasAdded = message.MembersAdded.Any(member => member.Id == message.Recipient.Id);
+                    var botWasAdded = message.MembersAdded.Any(member => member.Id == botId);
 
                     // Create the welcome message to send
                     Activity welcomeMessage = message.CreateReply();
@@ -175,7 +175,10 @@ namespace Microsoft.Teams.TemplateBotCSharp
                             }
                             else
                             {
-                                // First-run message has already been sent, so skip sending it again
+                                // First-run message has already been sent, so skip sending it again.
+                                // Do not remove the check for IsFreSent above. Your bot can receive spurious conversationUpdate
+                                // activities from chat service, so if you always respond to all of them, you will send random 
+                                // welcome messages to users who have already received the welcome.
                             }
                         }
                     }


### PR DESCRIPTION
* Detect condition where bot is added to 1:1 or team
* Check for previous welcome message before sending welcome to 1:1 chat
* Implement /resetbotchat to simulate a new conversation. Teams does not support re-creating a 1:1 chat, so the recommended approach is to simulate it.